### PR TITLE
docs: refresh readmes for research integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,12 @@ This repository is a modular, extensible platform for food-related machine learn
 
 - **ml_pipeline/**: Core ML experimentation suite (augmentation, pipelines, benchmarking, reproducibility, results)
 - **nut_agent/**: Streamlit-based conversational nutritionist agent (LLM + ML validation, user registration, session management)
+- **third_party/**: Lightweight loader utilities that let you point at official research repositories (e.g., MGS-GRF, TabEBM) without vendoring their code
 
 ## Getting Started
 
 - See `ml_pipeline/README.md` for details on data augmentation, model training, benchmarking, and reproducibility.
-- See `ml_pipeline/pipelines_torch/README.md` for pipeline and model registry usage.
+- See `ml_pipeline/pipelines_torch/README.md` for pipeline, semi-supervised utilities, and registry usage (tabular, vision, and third-party research models).
 - See `nut_agent/README.md` for the conversational agent, Streamlit UI, and user management features.
 
 ## Quickstart
@@ -28,5 +29,6 @@ This repository is a modular, extensible platform for food-related machine learn
 - All user data and chat logs are stored in `nut_agent/secrets/` (excluded from version control)
 - ML models are stored in `ml_pipeline/results/`
 - Modular design: add new models, augmentations, or agent tools with minimal friction
+- Official research repos can be linked via environment variables (e.g., `MGS_GRF_REPO`, `TABEBM_REPO`) so `ml_pipeline` loads upstream implementations without vendoring
 
 For full details, consult the README in each subfolder.

--- a/ml_pipeline/README.md
+++ b/ml_pipeline/README.md
@@ -14,6 +14,7 @@ Comprehensive machine learning experimentation and benchmarking suite for food-r
 
 ### 🔄 Advanced Data Augmentation
 - **Tabular augmentation**: SMOTE (all variants), Mixup, hybrid samplers, and cleaning (see `data_augmentation/augmentations.py`)
+- **Official research integrations**: Drop-in wrappers for MGS-GRF minority oversampling and TabEBM generative modeling (`pipelines_torch/augmentations.py` via `third_party/` loader)
 - **Text augmentation**: LLM-based (OpenAI, Gemini, HuggingFace) and classical (synonym, backtranslation, EDA) methods (`text_aug.py`)
 - **Image augmentation**: Classical (flip, rotate, noise) and Albumentations-based pipelines (`image_aug.py`)
 - **Registry pattern**: Easily add new augmentation methods; configure via registry and YAML/dict
@@ -22,6 +23,7 @@ Comprehensive machine learning experimentation and benchmarking suite for food-r
 ### 🏗️ Modular Model Pipelines
 - **PyTorch & sklearn pipelines**: Unified `GeneralPipeline` and `GeneralPipelineSklearn` for all model types
 - **Model registry**: Plug-and-play support for MLP, XGBoost, LightGBM, RandomForest, HuggingFace LoRA/QLoRA, Llama.cpp, and more (`models.py`)
+- **Semi-supervised wrappers**: Consistency regularization, Mean Teacher, pseudo-labeling, and contrastive vision SSL utilities (`pipelines_torch/ss_models.py`, `pipelines_torch/ss_vision_models.py`)
 - **K-fold CV & ensembling**: Built-in cross-validation, weight averaging, and metrics tracking
 - **Flexible metrics**: Custom and standard metrics for classification/regression
 - **Consistent epoch selection**: Centralized logic in `utils/utils.py` ensures perfect consistency between training weight selection and result reporting
@@ -32,6 +34,12 @@ Comprehensive machine learning experimentation and benchmarking suite for food-r
 - **Metrics**: Accuracy, F1, R², MSE, and more (`utils/metrics.py`)
 - **Visualization**: Training curves, confusion matrices, and result plots (`utils/visualization.py`)
 - **Model persistence**: Save/load models, HuggingFace Hub integration
+
+### 🧬 Semi-Supervised & Official Research Integrations
+- **Tabular SSL**: Mean Teacher, pseudo-labeling, and confidence-ramped consistency losses for any classifier (`ss_models.py`)
+- **Vision SSL**: Pseudo-label, Pi-Model, Mean Teacher, and STU-CSSIC style contrastive learning wrappers (`ss_vision_models.py`)
+- **Research augmentors**: Integrate state-of-the-art oversamplers/generators (MGS-GRF, TabEBM, Simplicial SMOTE, MEB-SMOTE) through `pipelines_torch/augmentations.py`
+- **External repo loader**: `third_party/` utilities auto-import official GitHub repos via path or environment variables—no vendoring required
 
 ---
 
@@ -47,13 +55,18 @@ ml_pipeline/
 │   ├── augmentations.py            # Tabular augmentation (SMOTE, Mixup, etc.)
 │   ├── image_aug.py                # Image augmentation (classical, Albumentations)
 │   ├── text_aug.py                 # Text augmentation (LLM, classical)
-├── pipelines_torch/                # Model pipelines and wrappers
+├── pipelines_torch/                # Model pipelines, registries, SSL, and research hooks
 │   ├── __init__.py
+│   ├── augmentations.py            # Official research augmentation wrappers (MGS-GRF, TabEBM, etc.)
 │   ├── base.py                     # GeneralPipeline, GeneralPipelineSklearn
 │   ├── benchmark.py                # BenchmarkRunner (grid search, result aggregation)
 │   ├── models.py                   # Model registry and wrappers
+│   ├── ss_models.py                # Semi-supervised tabular utilities
+│   ├── ss_vision_models.py         # Semi-supervised vision utilities
+│   ├── vision_models.py            # Vision/backbone registry
 ├── results/                        # Experiment results (CSV, per-task)
 │   ├── ...                         # Results for difficulty, meal type, nutrients, time, etc.
+├── third_party/                    # Loader utilities for external research repositories
 ├── utils/                          # Utilities for data, metrics, reproducibility
 │   ├── data.py
 │   ├── metrics.py
@@ -72,13 +85,15 @@ ml_pipeline/
 
 ### 2. Data Augmentation
 - Select augmentation via registry (see `AUGMENTATION_README.md`)
-- Tabular: SMOTE (regular, borderline, kmeans, SVM), Mixup, hybrid samplers, cleaning
+- Tabular: SMOTE (regular, borderline, kmeans, SVM), Mixup, hybrid samplers, cleaning, Simplicial SMOTE, MEB-SMOTE
+- Official research hooks: Call into MGS-GRF oversampling and TabEBM generation without copying their repos (requires pointing `third_party/` loader to the upstream code)
 - Text: LLM-based (OpenAI, Gemini, HuggingFace), classical (synonym, EDA, backtranslation)
 - Image: Classical and Albumentations pipelines
 - Configure augmentations via dict/YAML or registry name
 
 ### 3. Model Selection & Pipeline
 - Choose model from registry (`models.py`): MLP, XGBoost, LightGBM, RandomForest, HuggingFace LoRA/QLoRA, Llama.cpp, etc.
+- Wrap any classifier/regressor with semi-supervised helpers from `ss_models.py`/`ss_vision_models.py` when mixing labeled & unlabeled data
 - Use `GeneralPipeline` (PyTorch) or `GeneralPipelineSklearn` (sklearn) for unified training, CV, and evaluation
 - All pipelines support augmentations, metrics, k-fold CV, and model saving/loading
 
@@ -252,11 +267,22 @@ runner.run()
 ```
 
 ### Data Augmentation
-Use the scripts in `data_augmentation/` to augment your datasets. For example:
+Use the scripts in `data_augmentation/` or the research wrappers in `pipelines_torch/augmentations.py` to augment your datasets.
 
 ```python
 from data_augmentation.text_aug import augment_text
+from pipelines_torch.augmentations import MGS_GRF_Augmentor, SimplicialSMOTE
+
+# LLM- or classical-based text augmentation
 augmented_text = augment_text("Sample recipe description")
+
+# Official MGS-GRF oversampler (point THIRD_PARTY_ROOT/mgs-grf at the upstream repo)
+mgs = MGS_GRF_Augmentor()
+X_bal, y_bal = mgs.fit_resample(X, y, target_class=1, n_samples=200)
+
+# Native research-inspired sampler
+simplicial = SimplicialSMOTE()
+synthetic = simplicial.sample(X, y, target_class=1, n_samples=200)
 ```
 
 ### Utilities

--- a/ml_pipeline/data_augmentation/README.md
+++ b/ml_pipeline/data_augmentation/README.md
@@ -1,10 +1,11 @@
 # Data Augmentation Modules
 
-This folder contains augmentation modules for text, image, and tabular/numerical data:
+This folder contains augmentation modules for text, image, and tabular/numerical data, plus research-grade wrappers that live in `ml_pipeline/pipelines_torch/augmentations.py`:
 
 - **`text_aug.py`**: Text augmentation using LLM prompting (Google Gemini) and classical techniques (synonym replacement, random insertion, deletion, swap).
 - **`image_aug.py`**: Image augmentation using classical computer vision (OpenCV, PIL) and Albumentations library.
-- **`augmentations.py`**: Tabular/numerical data augmentation using SMOTE variants, Mixup, and hybrid samplers.
+- **`augmentations.py`**: Tabular/numerical data augmentation using SMOTE variants, Mixup, hybrid samplers, and research-inspired methods (Simplicial SMOTE, MEB-SMOTE).
+- **`../pipelines_torch/augmentations.py`**: Official research integrations (MGS-GRF oversampler, TabEBM generator) accessible through the shared registry pattern.
 
 ## Features
 
@@ -28,7 +29,6 @@ This folder contains augmentation modules for text, image, and tabular/numerical
 - Classical: Rotation, translation, scaling, flipping, brightness/contrast/saturation, noise, blur, elastic transform
 - Albumentations: Basic, geometric, noise/blur, color, weather, perspective
 
-
 #### Classical Techniques (OpenCV + PIL)
 - **Geometric Transformations**: Rotation, translation, scaling, flipping (`classical_rotation`, `classical_geometric`)
 - **Color Adjustments**: Brightness, contrast, saturation modifications (`classical_color`)
@@ -47,28 +47,18 @@ This folder contains augmentation modules for text, image, and tabular/numerical
 ### Tabular/Numerical Data Augmentation (`augmentations.py`)
 - SMOTE, BorderlineSMOTE, SVMSMOTE, KMeansSMOTE, ADASYN
 - Mixup, MixupSMOTE
+- SimplicialSMOTE (Kachan et al., 2025) for simplex-based interpolation
+- MEBSMOTE (Shangguan et al., 2024) for minimum enclosing ball oversampling
 - SMOTEENN, SMOTETomek
 - All oversampling methods (except mixup/none) apply TomekLinks cleaning
-- `max_factor` parameter controls minority/majority ratio
-
-
-#### SMOTE Variants
-- **SMOTE**: Synthetic Minority Over-sampling Technique (`smote`)
-- **BorderlineSMOTE**: SMOTE with borderline focus (`borderline_smote`)
-- **SVMSMOTE**: SMOTE using SVM support vectors (`svm_smote`)
-- **KMeansSMOTE**: SMOTE with K-means clustering (`kmeans_smote`)
-- **ADASYN**: Adaptive Synthetic Sampling (`adasyn`)
-
-#### Custom Techniques
-- **Mixup**: Linear interpolation between samples (`mixup`)
-- **MixupSMOTE**: Custom combination of Mixup and SMOTE (`mixup_smote`)
-
-#### Hybrid Samplers
-- **SMOTEENN**: SMOTE + Edited Nearest Neighbors (`smoteenn`)
-- **SMOTETomek**: SMOTE + Tomek Links (`smotetomek`)
-
-- All oversampling methods (except mixup/none) apply TomekLinks cleaning automatically.
 - The `max_factor` parameter controls the minority/majority ratio for most samplers.
+
+### Research Integrations (`../pipelines_torch/augmentations.py`)
+- **MGS_GRF_Augmentor**: Wraps the official MGS-GRF repository for guided minority sample generation
+- **TabEBMGenerator**: Wraps the official TabEBM (NeurIPS 2024) energy-based model for conditional sampling
+- **SimplicialSMOTE & MEBSMOTE**: Re-exported for registry-style usage alongside the official wrappers
+- Uses the shared `third_party/` loader to dynamically import upstream GitHub repositories without vendoring code
+- Configurable via explicit paths or environment variables (`MGS_GRF_REPO`, `TABEBM_REPO`)
 
 ## Usage Example
 
@@ -76,6 +66,7 @@ This folder contains augmentation modules for text, image, and tabular/numerical
 from text_aug import TEXT_AUGMENTATION_REGISTRY
 from image_aug import IMAGE_AUGMENTATION_REGISTRY
 from augmentations import AUGMENTATION_REGISTRY
+from pipelines_torch.augmentations import MGS_GRF_Augmentor
 
 # Text augmentation
 augmented_texts = TEXT_AUGMENTATION_REGISTRY["classical_synonym"](["Hello world"])
@@ -83,10 +74,24 @@ augmented_texts = TEXT_AUGMENTATION_REGISTRY["classical_synonym"](["Hello world"
 # Image augmentation
 augmented_images = IMAGE_AUGMENTATION_REGISTRY["classical_geometric"]([your_image_array])
 
-# Tabular/numerical augmentation
+# Tabular/numerical augmentation from the built-in registry
 X_aug, y_aug = AUGMENTATION_REGISTRY["smote"](X, y)
+
+# Official research augmentor (make sure the upstream repo is available)
+mgs = MGS_GRF_Augmentor()
+X_bal, y_bal = mgs.fit_resample(X, y, target_class=1, n_samples=128)
+```
+
+## Pointing to Official Repositories
+
+The `third_party/` loader automatically searches for cloned research repositories inside `third_party/`, custom paths, or environment variables. For example:
+
+```bash
+export MGS_GRF_REPO=/path/to/mgs-grf
+export TABEBM_REPO=/path/to/TabEBM
 ```
 
 ## Notes
 - For LLM-based text augmentation, set the `GOOGLE_API_KEY` environment variable.
 - All registry keys and features listed above are present in the code. See each file for full API and configuration options.
+- Research integrations require the official repositories to be available locally; see the example environment variables above.

--- a/ml_pipeline/pipelines_torch/README.md
+++ b/ml_pipeline/pipelines_torch/README.md
@@ -17,6 +17,12 @@ This module provides a unified, extensible framework for training, evaluating, a
 - **Custom wrappers**: All models are wrapped for compatibility with the pipeline interface.
 - **Easy extensibility**: Add new models by registering in `MODEL_REGISTRY`.
 
+### 🧬 Semi-Supervised & Research Hooks
+- **Consistency regularization**: Mean Teacher, Pi-Model, Pseudo-Labeling, and STU-CSSIC-inspired wrappers for both tabular and vision models (`ss_models.py`, `ss_vision_models.py`).
+- **Official augmentation bridges**: `augmentations.py` wraps state-of-the-art research repos (MGS-GRF, TabEBM) via the shared `third_party/` loader.
+- **Research samplers**: Native implementations of Simplicial SMOTE and MEB-SMOTE exposed alongside the official wrappers for registry-style access.
+- **Path-agnostic imports**: `third_party/` utilities resolve cloned repositories via explicit paths or environment variables (no vendoring needed).
+
 ### 🔄 Cross-Validation & Ensembling
 - **K-fold CV**: Built-in support for k-fold cross-validation, with weight averaging for PyTorch models.
 - **Metrics tracking**: Track and aggregate metrics (F1, R², etc.) across folds.
@@ -33,9 +39,12 @@ This module provides a unified, extensible framework for training, evaluating, a
 ```
 pipelines_torch/
 ├── __init__.py
+├── augmentations.py  # Official research augmentation wrappers + advanced samplers
 ├── base.py           # GeneralPipeline, GeneralPipelineSklearn
 ├── benchmark.py      # BenchmarkRunner (grid search, result aggregation)
 ├── models.py         # Model registry and wrappers (tabular/text models)
+├── ss_models.py      # Semi-supervised utilities for tabular models
+├── ss_vision_models.py  # Semi-supervised utilities for vision backbones
 ├── vision_models.py  # Computer vision model registry (CNNs, ViTs, CLIP, multimodal)
 ```
 
@@ -144,6 +153,48 @@ runner = BenchmarkRunner(
 )
 results_df = runner.run(X, y)
 ```
+
+### 5. Semi-Supervised Training
+
+```python
+from pipelines_torch.ss_models import SemiSupervisedTabular
+from pipelines_torch.models import MODEL_REGISTRY
+
+base = MODEL_REGISTRY['mlp_classifier'](input_dim=128, num_classes=5)
+ssl_model = SemiSupervisedTabular(base, num_classes=5)
+
+for epoch in range(num_epochs):
+    loss, logs = ssl_model.step(batch_labeled, batch_unlabeled, epoch)
+    loss.backward()
+    optimizer.step()
+    optimizer.zero_grad()
+    ssl_model.post_step()
+```
+
+### 6. Research Augmentations
+
+```python
+from pipelines_torch.augmentations import MGS_GRF_Augmentor, TabEBMGenerator
+
+# Point the loader to official repos (environment variables or explicit paths)
+mgs = MGS_GRF_Augmentor()
+tabebm = TabEBMGenerator()
+
+mgs_X, mgs_y = mgs.fit_resample(X_train, y_train, target_class=1, n_samples=200)
+tabebm.fit(X_train, y_train)
+synthetic = tabebm.sample(256, conditioned_on=1)
+```
+
+### Linking Official Research Repositories
+
+The `third_party/` helpers automatically look for cloned research repos inside `third_party/`, an explicit path, or environment variables. For example:
+
+```bash
+export MGS_GRF_REPO=/path/to/mgs-grf
+export TABEBM_REPO=/path/to/TabEBM
+```
+
+All loaders accept optional keyword arguments (`repo_path`, `env_var`, `module_candidates`) if you need to override the defaults.
 
 ---
 

--- a/nut_agent/README.md
+++ b/nut_agent/README.md
@@ -14,6 +14,7 @@ A sophisticated nutritionist agent built with LangGraph and Streamlit that lever
 - **Recipe Difficulty Prediction**: Validates difficulty classification (Easy, More effort, A challenge)
 - **Meal Type Classification**: Validates meal categorization (breakfast, lunch, dinner, snack, dessert)
 - **Total Time Classification**: Validates total cooking time class (e.g., under 30 min, 30-60 min, over 60 min)
+- **Research-grade models**: Plug in the latest `ml_pipeline` semi-supervised or official research models (MGS-GRF, TabEBM, etc.) without modifying the agent
 
 ### 🎯 Personalized Recommendations
 - **BMR/TDEE Calculations**: Science-based calorie target calculations using Mifflin-St Jeor equation
@@ -233,6 +234,7 @@ tools = [validate_recipe_with_ml_models, calculate_personalized_nutrition_target
    - `MACRO_RATIOS`: Macronutrient distribution ratios
 - **Add New Tools**: Use the `@tool` decorator in `improved_agent.py` and add to the tool list.
 - **Add/Change Models**: Update model paths and registry in `config.py` and `model_predictor.py`.
+- **Leverage research integrations**: Point environment variables (e.g., `MGS_GRF_REPO`, `TABEBM_REPO`) at official repos to use the newest `ml_pipeline` augmentors and semi-supervised models inside the agent.
 - **UI Customization**: Add new features or tabs in `streamlit_app.py`.
 
 ## Troubleshooting


### PR DESCRIPTION
## Summary
- document the new `third_party/` loader and research integration workflow across the project and pipeline READMEs
- highlight semi-supervised utilities and official research augmentors now available in `ml_pipeline`
- expand the augmentation and nutritionist agent docs with usage examples and environment configuration details

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d012ec4d788326ac88773409eb3c0d