### PR TITLE
Refactor SSL algorithms and remove in-house SMOTE variants

### DIFF
--- a/ml_pipeline/README.md
+++ b/ml_pipeline/README.md
@@ -13,7 +13,7 @@ Comprehensive machine learning experimentation and benchmarking suite for food-r
 - **Reproducibility**: Deterministic splits, seed control, and experiment tracking
 
 ### 🔄 Advanced Data Augmentation
-- **Tabular augmentation**: SMOTE (all variants), Mixup, Simplicial SMOTE, MEB-SMOTE, official MGS-GRF & TabEBM wrappers, hybrid samplers, and cleaning (see `data_augmentation/augmentations.py`)
+- **Tabular augmentation**: SMOTE (all variants), Mixup, official MGS-GRF & TabEBM wrappers, hybrid samplers, and cleaning (see `data_augmentation/augmentations.py`)
 - **Text augmentation**: LLM-based (OpenAI, Gemini, HuggingFace) and classical (synonym, backtranslation, EDA) methods (`text_aug.py`)
 - **Image augmentation**: Classical (flip, rotate, noise) and Albumentations-based pipelines (`image_aug.py`)
 - **Registry pattern**: Easily add new augmentation methods; configure via registry and YAML/dict

--- a/ml_pipeline/data_augmentation/README.md
+++ b/ml_pipeline/data_augmentation/README.md
@@ -4,7 +4,7 @@ This folder contains augmentation modules for text, image, and tabular/numerical
 
 - **`text_aug.py`**: Text augmentation using LLM prompting (Google Gemini) and classical techniques (synonym replacement, random insertion, deletion, swap).
 - **`image_aug.py`**: Image augmentation using classical computer vision (OpenCV, PIL) and Albumentations library.
-- **`augmentations.py`**: Tabular/numerical data augmentation using SMOTE variants, Mixup, Simplicial & MEB-SMOTE, official MGS-GRF/TabEBM wrappers, and hybrid samplers.
+- **`augmentations.py`**: Tabular/numerical data augmentation using SMOTE variants, Mixup, official MGS-GRF/TabEBM wrappers, and hybrid samplers.
 
 ## Features
 
@@ -47,7 +47,6 @@ This folder contains augmentation modules for text, image, and tabular/numerical
 ### Tabular/Numerical Data Augmentation (`augmentations.py`)
 - SMOTE, BorderlineSMOTE, SVMSMOTE, KMeansSMOTE, ADASYN
 - Mixup, MixupSMOTE
-- Simplicial SMOTE (2025) and MEB-SMOTE (2024) custom implementations
 - Official research wrappers for MGS-GRF (Artefactory) and TabEBM (NeurIPS 2024)
 - SMOTEENN, SMOTETomek
 - All oversampling methods (except mixup/none) apply TomekLinks cleaning
@@ -57,10 +56,6 @@ This folder contains augmentation modules for text, image, and tabular/numerical
 #### Official Research Wrappers
 - **MGS_GRF_Augmentor**: Calls the Artefactory `mgs-grf` implementation for mixed-type oversampling (requires cloning the repo or installing from source).
 - **TabEBMGenerator**: Wraps the official TabEBM energy-based sampler to learn class-conditional densities before drawing synthetic samples.
-
-#### Recent Research-Inspired Additions
-- **SimplicialSMOTE**: Samples points inside simplices spanned by minority neighbours to better cover complex manifolds.
-- **MEBSMOTE**: Generates synthetic samples inside minimum enclosing balls around minority clusters for safer oversampling.
 
 #### SMOTE Variants
 - **SMOTE**: Synthetic Minority Over-sampling Technique (`smote`)

--- a/ml_pipeline/pipelines_torch/README.md
+++ b/ml_pipeline/pipelines_torch/README.md
@@ -19,11 +19,10 @@ This module provides a unified, extensible framework for training, evaluating, a
 
 ### 🧪 Semi-Supervised Learning Utilities
 - **Vision SSL** (`ss_vision_models.py`): Implements Pseudo-Label, Pi-Model, Mean Teacher, and CDMAD debiasing while keeping hooks compatible with official repositories.
-- **Tabular SSL** (`ss_models.py`): General-purpose pseudo-labeling + EMA framework that can wrap any registry model and plug in tabular augmentations.
+- **Tabular SSL** (`ss_models.py`): Wraps any registry model with the same reusable SSL algorithms (pseudo-labeling or Mean Teacher) plus optional tabular-specific augmentations.
 
 ### 🧬 Advanced Augmentations (`augmentations.py`)
 - **Official research integrations**: Wrappers for MGS-GRF (Artefactory, 2025) and TabEBM (NeurIPS 2024) sourced directly from their repositories.
-- **Recent SMOTE variants**: Custom implementations of Simplicial SMOTE (2025) and MEB-SMOTE (2024) for handling mixed continuous/categorical data.
 
 ### 🔄 Cross-Validation & Ensembling
 - **K-fold CV**: Built-in support for k-fold cross-validation with optional weight averaging.
@@ -47,6 +46,7 @@ pipelines_torch/
 ├── vision_models.py    # Vision model registry (CNNs, CLIP, FatFormer, DiffusionFake, etc.)
 ├── ss_models.py        # Tabular semi-supervised wrappers
 ├── ss_vision_models.py # Vision semi-supervised algorithms & hooks
+├── ssl_algorithms.py   # Shared implementations of pseudo-label, Pi-Model, and Mean Teacher
 ├── augmentations.py    # Tabular augmentation strategies (MGS-GRF, TabEBM, SMOTE variants)
 └── ...
 ```
@@ -85,12 +85,12 @@ Use `get_model("model_name", ...)` to instantiate any vision model; tabular/text
 
 ### Vision (`ss_vision_models.py`)
 Provides loss wrappers that can sit on top of any vision backbone:
-- `PseudoLabel`, `PiModel`, `MeanTeacher`: Classical SSL baselines implemented from scratch in PyTorch.
+- `PseudoLabel`, `PiModel`, `MeanTeacher`: Classical SSL baselines implemented once in `ssl_algorithms.py` and reused across vision and tabular pipelines.
 - `CDMADHook`: Debias pseudo-labels using the official CDMAD repository or a faithful fallback implementation.
 - Hooks return `(supervised_loss, unsupervised_loss, logs)` so you can integrate them into existing training loops.
 
 ### Tabular (`ss_models.py`)
-- `SemiSupervisedTabular`: Wraps any registry model, performs pseudo-labeling with optional EMA teacher updates, and exposes augmentation hooks.
+- `SemiSupervisedTabular`: Wraps any registry model, reusing the shared pseudo-label or Mean Teacher implementations with optional Gaussian-noise augmentation hooks.
 - Designed to operate with the augmentation utilities in `augmentations.py` for minority-class oversampling or consistency regularization.
 
 ---
@@ -98,7 +98,6 @@ Provides loss wrappers that can sit on top of any vision backbone:
 ## Tabular Augmentations (`augmentations.py`)
 - `MGS_GRF_Augmentor`: Calls the official mixed-type oversampling implementation (requires cloning `artefactory/mgs-grf` or setting `MGS_GRF_REPO`).
 - `TabEBMGenerator`: Interfaces with the official TabEBM energy-based sampler (set `TABEBM_REPO` if the repo lives elsewhere).
-- `SimplicialSMOTE`, `MEBSMOTE`: Recent SMOTE variants implemented in-house for datasets where official code is unavailable.
 
 Each class operates on NumPy arrays and can be injected into pipelines or SSL routines as needed.
 

--- a/ml_pipeline/pipelines_torch/augmentations.py
+++ b/ml_pipeline/pipelines_torch/augmentations.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 from typing import Optional, Sequence, Tuple
 
 import numpy as np
-from sklearn.neighbors import NearestNeighbors
 
 from third_party import load_class
 
@@ -64,75 +63,3 @@ class TabEBMGenerator:
             return self.model.sample(n_samples)
         return self.model.sample_conditioned(n_samples, conditioned_on)
 
-
-class SimplicialSMOTE:
-    """Implementation of Simplicial SMOTE (Kachan et al., 2025)."""
-
-    def __init__(
-        self,
-        *,
-        neighbors: int = 4,
-        random_state: int = 42,
-        noise: float = 0.0,
-    ) -> None:
-        if neighbors < 2:
-            raise ValueError("neighbors must be >= 2 for simplicial interpolation")
-        self.neighbors = neighbors
-        self.random_state = np.random.RandomState(random_state)
-        self.noise = noise
-
-    def _sample_simplex(self, points: np.ndarray) -> np.ndarray:
-        weights = self.random_state.dirichlet(np.ones(points.shape[0]))
-        sample = weights @ points
-        if self.noise > 0:
-            sample = sample + self.random_state.normal(0, self.noise, size=sample.shape)
-        return sample
-
-    def sample(self, X: np.ndarray, y: np.ndarray, target_class: int, n_samples: int) -> np.ndarray:
-        minority_idx = np.where(y == target_class)[0]
-        if minority_idx.size == 0:
-            raise ValueError("Target class has no samples to interpolate from.")
-        nbrs = NearestNeighbors(n_neighbors=min(self.neighbors, minority_idx.size)).fit(X[minority_idx])
-        synthetic = []
-        for _ in range(n_samples):
-            anchor_id = self.random_state.choice(minority_idx)
-            anchor = X[anchor_id]
-            _, indices = nbrs.kneighbors(anchor.reshape(1, -1), return_distance=True)
-            neighbor_points = X[minority_idx][indices[0]]
-            simplex_points = np.vstack([anchor, neighbor_points])
-            synthetic.append(self._sample_simplex(simplex_points))
-        return np.asarray(synthetic)
-
-
-class MEBSMOTE:
-    """Minimum enclosing ball SMOTE (Shangguan et al., 2024)."""
-
-    def __init__(
-        self,
-        *,
-        neighbors: int = 5,
-        random_state: int = 42,
-    ) -> None:
-        if neighbors < 1:
-            raise ValueError("neighbors must be >=1")
-        self.neighbors = neighbors
-        self.random_state = np.random.RandomState(random_state)
-
-    def sample(self, X: np.ndarray, y: np.ndarray, target_class: int, n_samples: int) -> np.ndarray:
-        minority_idx = np.where(y == target_class)[0]
-        if minority_idx.size == 0:
-            raise ValueError("Target class has no samples")
-        nbrs = NearestNeighbors(n_neighbors=min(self.neighbors, minority_idx.size)).fit(X[minority_idx])
-        synthetic = []
-        for _ in range(n_samples):
-            anchor_id = self.random_state.choice(minority_idx)
-            anchor = X[anchor_id]
-            _, indices = nbrs.kneighbors(anchor.reshape(1, -1), return_distance=True)
-            neighbors_pts = X[minority_idx][indices[0]]
-            centroid = neighbors_pts.mean(axis=0)
-            radius = np.linalg.norm(neighbors_pts - centroid, axis=1).max()
-            direction = centroid - anchor
-            new_point = anchor + self.random_state.rand() * direction
-            jitter = self.random_state.normal(0, radius * 0.05, size=new_point.shape)
-            synthetic.append(new_point + jitter)
-        return np.asarray(synthetic)

--- a/ml_pipeline/pipelines_torch/ss_models.py
+++ b/ml_pipeline/pipelines_torch/ss_models.py
@@ -1,24 +1,16 @@
 """Semi-supervised learning utilities for tabular models."""
 from __future__ import annotations
 
-from copy import deepcopy
-from math import cos, pi
 from typing import Dict, Tuple
 
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
 
-
-def _cosine_rampup(step: int, rampup: int) -> float:
-    if rampup <= 0:
-        return 1.0
-    step = max(0, min(step, rampup))
-    return float(0.5 - 0.5 * cos(pi * step / rampup))
+from .ssl_algorithms import MeanTeacher, PseudoLabel
 
 
 class SemiSupervisedTabular(nn.Module):
-    """Generic semi-supervised wrapper for tabular models."""
+    """Wrap tabular backbones with reusable SSL algorithms."""
 
     def __init__(
         self,
@@ -31,35 +23,45 @@ class SemiSupervisedTabular(nn.Module):
         unsup_weight: float = 1.0,
         rampup: int = 5,
         noise_std: float = 0.02,
+        temperature: float = 1.0,
     ) -> None:
         super().__init__()
-        self.base = base_model
         self.num_classes = num_classes
         self.use_mean_teacher = use_mean_teacher
-        self.ema_decay = ema_decay
-        self.threshold = threshold
-        self.unsup_weight = unsup_weight
-        self.rampup = rampup
         self.noise_std = noise_std
+
         if self.use_mean_teacher:
-            self.teacher = deepcopy(base_model).eval()
-            for param in self.teacher.parameters():
-                param.requires_grad_(False)
+            self.ssl_model = MeanTeacher(
+                base_model,
+                ema_decay=ema_decay,
+                unsup_weight=unsup_weight,
+                rampup=rampup,
+                temperature=temperature,
+                weak=self._weak,
+                strong=self._strong,
+            )
         else:
-            self.teacher = None
+            self.ssl_model = PseudoLabel(
+                base_model,
+                threshold=threshold,
+                unsup_weight=unsup_weight,
+                rampup=rampup,
+                weak=self._weak,
+                strong=self._strong,
+            )
+
+        self.base = self.ssl_model.backbone
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:  # type: ignore[override]
-        return self.base(x)
+        return self.ssl_model(x)
 
-    def _augment(self, x: torch.Tensor, std: float) -> torch.Tensor:
-        if std <= 0:
+    def _weak(self, x: torch.Tensor) -> torch.Tensor:
+        return x
+
+    def _strong(self, x: torch.Tensor) -> torch.Tensor:
+        if self.noise_std <= 0:
             return x
-        return x + std * torch.randn_like(x)
-
-    def _teacher_predict(self, x: torch.Tensor) -> torch.Tensor:
-        if self.teacher is not None:
-            return self.teacher(x)
-        return self.base(x)
+        return x + self.noise_std * torch.randn_like(x)
 
     def step(
         self,
@@ -67,28 +69,11 @@ class SemiSupervisedTabular(nn.Module):
         batch_u: Tuple[torch.Tensor, torch.Tensor | None],
         epoch: int,
     ) -> Tuple[torch.Tensor, Dict[str, float]]:
-        x_l, y_l = batch_l
-        x_u, _ = batch_u
-
-        logits_l = self(self._augment(x_l, 0.0))
-        loss_sup = F.cross_entropy(logits_l, y_l)
-
-        with torch.no_grad():
-            teacher_logits = self._teacher_predict(self._augment(x_u, 0.0))
-            probs = torch.softmax(teacher_logits, dim=1)
-            confidence, pseudo = probs.max(dim=1)
-            mask = (confidence >= self.threshold).float()
-
-        logits_u = self(self._augment(x_u, self.noise_std))
-        loss_unsup = (F.cross_entropy(logits_u, pseudo, reduction="none") * mask).mean()
-        weight = self.unsup_weight * _cosine_rampup(epoch, self.rampup)
-        total_loss = loss_sup + weight * loss_unsup
-        logs = {"mask_rate": mask.mean().item(), "weight": weight}
+        loss_sup, loss_unsup, logs = self.ssl_model.ssl_loss(batch_l, batch_u, epoch)
+        total_loss = loss_sup + loss_unsup
         return total_loss, logs
 
     @torch.no_grad()
     def post_step(self) -> None:
-        if self.teacher is None:
-            return
-        for teacher_param, student_param in zip(self.teacher.parameters(), self.base.parameters()):
-            teacher_param.data.mul_(self.ema_decay).add_(student_param.data, alpha=1 - self.ema_decay)
+        if hasattr(self.ssl_model, "update_teacher"):
+            self.ssl_model.update_teacher()

--- a/ml_pipeline/pipelines_torch/ss_vision_models.py
+++ b/ml_pipeline/pipelines_torch/ss_vision_models.py
@@ -1,8 +1,6 @@
 """Semi-supervised vision algorithms with optional hooks to official research repositories."""
 from __future__ import annotations
 
-from copy import deepcopy
-from math import cos, pi
 from typing import Dict, Optional, Tuple
 
 import torch
@@ -10,189 +8,32 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 from third_party import load_class, load_function
+from .ssl_algorithms import (
+    MeanTeacher as _MeanTeacher,
+    PiModel as _PiModel,
+    PseudoLabel as _PseudoLabel,
+    SemiSupervisedClassifier,
+    cosine_rampup as _cosine_rampup,
+)
+
+__all__ = [
+    "SSLImageClassifier",
+    "PseudoLabel",
+    "PiModel",
+    "MeanTeacher",
+    "CDMADDebiased",
+]
+
+PseudoLabel = _PseudoLabel
+PiModel = _PiModel
+MeanTeacher = _MeanTeacher
 
 
-def _cosine_rampup(cur_step: int, rampup: int) -> float:
-    if rampup <= 0:
-        return 1.0
-    cur_step = max(0, min(cur_step, rampup))
-    return float(0.5 - 0.5 * cos(pi * cur_step / rampup))
-
-
-class SSLImageClassifier(nn.Module):
+class SSLImageClassifier(SemiSupervisedClassifier):
     """Base wrapper exposing a torch.nn.Module compatible interface."""
 
-    def __init__(self, backbone: nn.Module) -> None:
-        super().__init__()
-        self.backbone = backbone
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:  # type: ignore[override]
-        return self.backbone(x)
-
-    def ssl_loss(
-        self,
-        batch_l: Tuple[torch.Tensor, torch.Tensor],
-        batch_u: Tuple[torch.Tensor, torch.Tensor | None],
-        epoch: int,
-    ) -> Tuple[torch.Tensor, torch.Tensor, Dict[str, float]]:
-        raise NotImplementedError
-
-    @torch.no_grad()
-    def _weak(self, x: torch.Tensor) -> torch.Tensor:
-        return x
-
-    @torch.no_grad()
-    def _strong(self, x: torch.Tensor) -> torch.Tensor:
-        return x
-
-
-class PseudoLabel(SSLImageClassifier):
-    def __init__(self, backbone: nn.Module, *, threshold: float = 0.95, unsup_weight: float = 1.0, rampup: int = 5) -> None:
-        super().__init__(backbone)
-        self.threshold = threshold
-        self.unsup_weight = unsup_weight
-        self.rampup = rampup
-
-    def ssl_loss(self, batch_l, batch_u, epoch):
-        x_l, y_l = batch_l
-        x_u, _ = batch_u
-        logits_l = self(x_l)
-        loss_sup = F.cross_entropy(logits_l, y_l)
-
-        with torch.no_grad():
-            logits_w = self(self._weak(x_u))
-            probs = torch.softmax(logits_w, dim=1)
-            confidence, pseudo = probs.max(dim=1)
-            mask = (confidence >= self.threshold).float()
-
-        logits_s = self(self._strong(x_u))
-        loss_unsup = (F.cross_entropy(logits_s, pseudo, reduction="none") * mask).mean()
-        weight = self.unsup_weight * _cosine_rampup(epoch, self.rampup)
-        return loss_sup, weight * loss_unsup, {"mask_rate": mask.mean().item(), "weight": weight}
-
-
-class PiModel(SSLImageClassifier):
-    def __init__(self, backbone: nn.Module, *, unsup_weight: float = 1.0, rampup: int = 5, temperature: float = 1.0) -> None:
-        super().__init__(backbone)
-        self.unsup_weight = unsup_weight
-        self.rampup = rampup
-        self.temperature = temperature
-
-    def ssl_loss(self, batch_l, batch_u, epoch):
-        x_l, y_l = batch_l
-        x_u, _ = batch_u
-        logits_l = self(x_l)
-        loss_sup = F.cross_entropy(logits_l, y_l)
-
-        probs_w = torch.softmax(self(self._weak(x_u)) / self.temperature, dim=1)
-        probs_s = torch.softmax(self(self._strong(x_u)) / self.temperature, dim=1)
-        loss_unsup = F.mse_loss(probs_w, probs_s)
-        weight = self.unsup_weight * _cosine_rampup(epoch, self.rampup)
-        return loss_sup, weight * loss_unsup, {"weight": weight}
-
-
-class MeanTeacher(SSLImageClassifier):
-    def __init__(
-        self,
-        backbone: nn.Module,
-        *,
-        ema_decay: float = 0.999,
-        unsup_weight: float = 1.0,
-        rampup: int = 5,
-        temperature: float = 1.0,
-    ) -> None:
-        super().__init__(backbone)
-        self.teacher = deepcopy(backbone).eval()
-        for param in self.teacher.parameters():
-            param.requires_grad_(False)
-        self.ema_decay = ema_decay
-        self.unsup_weight = unsup_weight
-        self.rampup = rampup
-        self.temperature = temperature
-
-    def ssl_loss(self, batch_l, batch_u, epoch):
-        x_l, y_l = batch_l
-        x_u, _ = batch_u
-        logits_l = self(x_l)
-        loss_sup = F.cross_entropy(logits_l, y_l)
-
-        with torch.no_grad():
-            teacher_logits = self.teacher(self._weak(x_u))
-            teacher_probs = torch.softmax(teacher_logits / self.temperature, dim=1)
-
-        student_probs = torch.softmax(self(self._strong(x_u)) / self.temperature, dim=1)
-        loss_unsup = F.mse_loss(student_probs, teacher_probs)
-        weight = self.unsup_weight * _cosine_rampup(epoch, self.rampup)
-        logs = {"weight": weight, "_update_teacher": True}
-        return loss_sup, weight * loss_unsup, logs
-
-    @torch.no_grad()
-    def update_teacher(self) -> None:
-        for teacher_param, student_param in zip(self.teacher.parameters(), self.backbone.parameters()):
-            teacher_param.data.mul_(self.ema_decay).add_(student_param.data, alpha=1 - self.ema_decay)
-
-
-class STUCSSIC(SSLImageClassifier):
-    """Self-adaptive threshold + unreliable sample contrastive learning (Zhang et al., 2024)."""
-
-    def __init__(
-        self,
-        backbone: nn.Module,
-        num_classes: int,
-        *,
-        base_threshold: float = 0.95,
-        min_threshold: float = 0.6,
-        projection_dim: int = 128,
-        temperature: float = 0.5,
-        unsup_weight: float = 1.0,
-        rampup: int = 10,
-    ) -> None:
-        super().__init__(backbone)
-        self.num_classes = num_classes
-        self.base_threshold = base_threshold
-        self.min_threshold = min_threshold
-        self.temperature = temperature
-        self.unsup_weight = unsup_weight
-        self.rampup = rampup
-        self.projector = nn.Linear(num_classes, projection_dim)
-        self.register_buffer("class_thresholds", torch.full((num_classes,), base_threshold))
-
-    def _update_thresholds(self, epoch: int) -> None:
-        relax = _cosine_rampup(epoch, self.rampup)
-        updated = self.min_threshold + (self.base_threshold - self.min_threshold) * (1.0 - relax)
-        self.class_thresholds.copy_(torch.full_like(self.class_thresholds, updated))
-
-    def ssl_loss(self, batch_l, batch_u, epoch):
-        self._update_thresholds(epoch)
-        x_l, y_l = batch_l
-        x_u, _ = batch_u
-        logits_l = self(x_l)
-        loss_sup = F.cross_entropy(logits_l, y_l)
-
-        with torch.no_grad():
-            logits_w = self(self._weak(x_u))
-            probs_w = torch.softmax(logits_w, dim=1)
-            confidence, pseudo = probs_w.max(dim=1)
-            thresholds = self.class_thresholds[pseudo]
-            reliable = (confidence >= thresholds).float()
-
-        logits_s = self(self._strong(x_u))
-        loss_ce = (F.cross_entropy(logits_s, pseudo, reduction="none") * reliable).mean()
-
-        unreliable_idx = (reliable < 0.5).nonzero(as_tuple=True)[0]
-        loss_con = torch.tensor(0.0, device=x_u.device)
-        if unreliable_idx.numel() > 0:
-            proj_w = F.normalize(self.projector(probs_w[unreliable_idx]), dim=1)
-            proj_s = F.normalize(self.projector(torch.softmax(logits_s[unreliable_idx], dim=1)), dim=1)
-            similarity = proj_w @ proj_s.t() / self.temperature
-            targets = torch.arange(similarity.size(0), device=similarity.device)
-            loss_con = F.cross_entropy(similarity, targets)
-
-        weight = self.unsup_weight * _cosine_rampup(epoch, self.rampup)
-        return loss_sup, weight * (loss_ce + loss_con), {
-            "reliable_rate": reliable.mean().item(),
-            "weight": weight,
-        }
+    def __init__(self, backbone: nn.Module, *, weak=None, strong=None) -> None:
+        super().__init__(backbone, weak=weak, strong=strong)
 
 
 class CDMADDebiased(SSLImageClassifier):

--- a/ml_pipeline/pipelines_torch/ssl_algorithms.py
+++ b/ml_pipeline/pipelines_torch/ssl_algorithms.py
@@ -1,0 +1,159 @@
+"""Reusable semi-supervised learning algorithms for classification models."""
+from __future__ import annotations
+
+from copy import deepcopy
+from math import cos, pi
+from typing import Callable, Dict, Optional, Tuple
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+Tensor = torch.Tensor
+AugmentFn = Optional[Callable[[Tensor], Tensor]]
+
+
+def cosine_rampup(cur_step: int, rampup: int) -> float:
+    """Cosine ramp-up used to gradually scale unsupervised losses."""
+    if rampup <= 0:
+        return 1.0
+    cur_step = max(0, min(cur_step, rampup))
+    return float(0.5 - 0.5 * cos(pi * cur_step / rampup))
+
+
+class SemiSupervisedClassifier(nn.Module):
+    """Base wrapper that injects optional weak/strong augmentations."""
+
+    def __init__(self, backbone: nn.Module, *, weak: AugmentFn = None, strong: AugmentFn = None) -> None:
+        super().__init__()
+        self.backbone = backbone
+        self._weak_aug = weak
+        self._strong_aug = strong
+
+    def forward(self, x: Tensor) -> Tensor:  # type: ignore[override]
+        return self.backbone(x)
+
+    def _weak(self, x: Tensor) -> Tensor:
+        if self._weak_aug is None:
+            return x
+        return self._weak_aug(x)
+
+    def _strong(self, x: Tensor) -> Tensor:
+        if self._strong_aug is None:
+            return x
+        return self._strong_aug(x)
+
+    def ssl_loss(
+        self,
+        batch_l: Tuple[Tensor, Tensor],
+        batch_u: Tuple[Tensor, Optional[Tensor]],
+        epoch: int,
+    ) -> Tuple[Tensor, Tensor, Dict[str, float]]:
+        raise NotImplementedError
+
+
+class PseudoLabel(SemiSupervisedClassifier):
+    def __init__(
+        self,
+        backbone: nn.Module,
+        *,
+        threshold: float = 0.95,
+        unsup_weight: float = 1.0,
+        rampup: int = 5,
+        weak: AugmentFn = None,
+        strong: AugmentFn = None,
+    ) -> None:
+        super().__init__(backbone, weak=weak, strong=strong)
+        self.threshold = threshold
+        self.unsup_weight = unsup_weight
+        self.rampup = rampup
+
+    def ssl_loss(self, batch_l, batch_u, epoch):
+        x_l, y_l = batch_l
+        x_u, _ = batch_u
+        logits_l = self(x_l)
+        loss_sup = F.cross_entropy(logits_l, y_l)
+
+        with torch.no_grad():
+            logits_w = self(self._weak(x_u))
+            probs = torch.softmax(logits_w, dim=1)
+            confidence, pseudo = probs.max(dim=1)
+            mask = (confidence >= self.threshold).float()
+
+        logits_s = self(self._strong(x_u))
+        loss_unsup = (F.cross_entropy(logits_s, pseudo, reduction="none") * mask).mean()
+        weight = self.unsup_weight * cosine_rampup(epoch, self.rampup)
+        return loss_sup, weight * loss_unsup, {"mask_rate": mask.mean().item(), "weight": weight}
+
+
+class PiModel(SemiSupervisedClassifier):
+    def __init__(
+        self,
+        backbone: nn.Module,
+        *,
+        unsup_weight: float = 1.0,
+        rampup: int = 5,
+        temperature: float = 1.0,
+        weak: AugmentFn = None,
+        strong: AugmentFn = None,
+    ) -> None:
+        super().__init__(backbone, weak=weak, strong=strong)
+        self.unsup_weight = unsup_weight
+        self.rampup = rampup
+        self.temperature = temperature
+
+    def ssl_loss(self, batch_l, batch_u, epoch):
+        x_l, y_l = batch_l
+        x_u, _ = batch_u
+        logits_l = self(x_l)
+        loss_sup = F.cross_entropy(logits_l, y_l)
+
+        probs_w = torch.softmax(self(self._weak(x_u)) / self.temperature, dim=1)
+        probs_s = torch.softmax(self(self._strong(x_u)) / self.temperature, dim=1)
+        loss_unsup = F.mse_loss(probs_w, probs_s)
+        weight = self.unsup_weight * cosine_rampup(epoch, self.rampup)
+        return loss_sup, weight * loss_unsup, {"weight": weight}
+
+
+class MeanTeacher(SemiSupervisedClassifier):
+    def __init__(
+        self,
+        backbone: nn.Module,
+        *,
+        ema_decay: float = 0.999,
+        unsup_weight: float = 1.0,
+        rampup: int = 5,
+        temperature: float = 1.0,
+        weak: AugmentFn = None,
+        strong: AugmentFn = None,
+    ) -> None:
+        super().__init__(backbone, weak=weak, strong=strong)
+        self.teacher = deepcopy(backbone).eval()
+        for param in self.teacher.parameters():
+            param.requires_grad_(False)
+        self.ema_decay = ema_decay
+        self.unsup_weight = unsup_weight
+        self.rampup = rampup
+        self.temperature = temperature
+
+    def ssl_loss(self, batch_l, batch_u, epoch):
+        x_l, y_l = batch_l
+        x_u, _ = batch_u
+        logits_l = self(x_l)
+        loss_sup = F.cross_entropy(logits_l, y_l)
+
+        with torch.no_grad():
+            teacher_logits = self.teacher(self._weak(x_u))
+            teacher_probs = torch.softmax(teacher_logits / self.temperature, dim=1)
+
+        student_probs = torch.softmax(self(self._strong(x_u)) / self.temperature, dim=1)
+        loss_unsup = F.mse_loss(student_probs, teacher_probs)
+        weight = self.unsup_weight * cosine_rampup(epoch, self.rampup)
+        logs = {"weight": weight, "_update_teacher": True}
+        return loss_sup, weight * loss_unsup, logs
+
+    @torch.no_grad()
+    def update_teacher(self) -> None:
+        for teacher_param, student_param in zip(self.teacher.parameters(), self.backbone.parameters()):
+            teacher_param.data.mul_(self.ema_decay).add_(student_param.data, alpha=1 - self.ema_decay)


### PR DESCRIPTION
## Summary
- consolidate Pseudo-Label, Pi-Model, and Mean Teacher implementations in a shared `ssl_algorithms.py` module
- update vision and tabular semi-supervised wrappers to reuse the shared algorithms and drop the STUCSSIC variant
- remove unsupported Simplicial SMOTE and MEB-SMOTE classes and refresh documentation to reflect the streamlined feature set

## Testing
- python -m compileall ml_pipeline/pipelines_torch

------
https://chatgpt.com/codex/tasks/task_e_68d0196f4b848326945d7335b4d0e5f1